### PR TITLE
add eco team to blueprints

### DIFF
--- a/orgs/opentelekomcloud-blueprints/teams/members.yml
+++ b/orgs/opentelekomcloud-blueprints/teams/members.yml
@@ -1,2 +1,10 @@
 ---
-teams: {}
+teams:
+  eco:
+    description: Ecosystem
+    visibility: visible
+    parent:
+    maintainer:
+      - gtema
+    member:
+      - vineet-pruthi


### PR DESCRIPTION
FIXES:
NoneType: None
fatal: [bridge.eco.tsi-dev.otc-service.com]: FAILED! => {
    "changed": true,
    "rc": 1
}

STDOUT:

Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1623401187.850707-2722713-105640726112764/github_api.py", line 228, in <module>
    update_teams(
  File "/root/.ansible/tmp/ansible-tmp-1623401187.850707-2722713-105640726112764/github_api.py", line 149, in update_teams
    members_to_add = new_teams['teams'][team['name']]
KeyError: 'eco'
that was in TASK [gitcontrol : Update teams in opentelekomcloud-blueprints]