### PR TITLE
Move templates to the root

### DIFF
--- a/templates/default_zuul.yml
+++ b/templates/default_zuul.yml
@@ -1,0 +1,21 @@
+---
+required_status_checks:
+  strict: false
+  contexts:
+    - eco/check
+enforce_admins: true
+required_pull_request_reviews:
+  dismissal_restrictions:
+    users: []
+    teams: []
+  dismiss_stale_reviews: true
+  require_code_owner_reviews: false
+  required_approving_review_count: 1
+who_can_push:
+  users: []
+  teams: []
+  apps:
+    - otc-zuul
+required_linear_history: false
+allow_force_pushes: false
+allow_deletions: false


### PR DESCRIPTION
In the scope of moving role into the ansible collection we need a place
to store branch protection templates. Move them into the root of the
project.
