### PR TITLE
Remove non-existing team

### DIFF
--- a/orgs/opentelekomcloud-infra/repositories/terraform-setter-lint.yml
+++ b/orgs/opentelekomcloud-infra/repositories/terraform-setter-lint.yml
@@ -18,7 +18,6 @@ terraform-setter-lint:
     pull:
     push:
       - eco
-      - gophers
     admin:
   collaborators:
     maintain:


### PR DESCRIPTION
Remove non-existing team from `terraform-setter-lint` repo